### PR TITLE
fix: remove new lines from ref commit hash in getCommitsSinceRef function

### DIFF
--- a/.changeset/thick-swans-switch.md
+++ b/.changeset/thick-swans-switch.md
@@ -1,0 +1,5 @@
+---
+'changeset-conventional-commits': patch
+---
+
+Fixed new line markers in git command causing errors

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -155,6 +155,9 @@ export const getCommitsSinceRef = (branch: string) => {
       sinceRef = execSync('git rev-list --max-parents=0 HEAD').toString();
     }
   }
+
+  sinceRef = sinceRef.trim();
+
   return execSync(`git rev-list --ancestry-path ${sinceRef}...HEAD`).toString().split('\n').filter(Boolean).reverse();
 };
 


### PR DESCRIPTION
Here's a small fix that removes the newline markers from exec's output, which in my case was crashing the tool.

Great work on the lib, btw.

Cheers!