### PR TITLE
fix: duplicate generation of changesets (#26)

### DIFF
--- a/.changeset/wet-adults-taste.md
+++ b/.changeset/wet-adults-taste.md
@@ -1,0 +1,47 @@
+---
+'changeset-conventional-commits': patch
+---
+
+fix: duplicate generation of changesets (#26)
+
+The same changesets were generated again, because the duplicate detection failed on trailing line breaks (`\n`) it got from `git`.
+
+<details>
+  <summary>Details</summary>
+  Imagine this data it holds while duplicate checking:
+
+  `const changesets = ...:`
+
+  ```ts
+  // Data from Commits
+  [
+    {
+      releases: [[Object], [Object]],
+      summary: 'chore(root): add two test packages\n',
+      packagesChanged: [[Object], [Object]],
+    },
+  ];
+  ```
+
+  `const currentChangesets = ...:`
+
+  ```ts
+  // Data from Changesets
+  [
+    {
+      releases: [[Object], [Object]],
+      summary: 'chore(root): add two test packages',
+      packagesChanged: [[Object], [Object]],
+    },
+  ];
+  ```
+
+  Truncating the linebreak at [line 165](https://github.com/iamchathu/changeset-conventional-commits/blob/a4d324693eca549b0d016a162442eef49477ec75/src/utils/index.ts#L165) of `src/utils/index.ts` fixed it:
+
+  ```ts
+  const compareChangeSet = (a: Changeset, b: Changeset): boolean => {
+    // return a.summary === b.summary && JSON.stringify(a.releases) == JSON.stringify(b.releases);
+    return a.summary.replace(/\n$/, '') === b.summary && JSON.stringify(a.releases) == JSON.stringify(b.releases);
+  };
+  ```
+</details>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import { Changeset } from '@changesets/types';
+
 export interface PkgJson {
   name?: string;
   version?: string;
@@ -30,3 +32,11 @@ export interface ManyPkgPackages {
   packages: ManyPkgPackage[];
   root: ManyPkgPackage;
 }
+
+export type ChangesetConventionalCommit = Changeset & {
+  packagesChanged: {
+    dir: string;
+    relativeDir: string;
+    packageJson: PkgJson;
+  }[];
+};

--- a/src/utils/index.spec.ts
+++ b/src/utils/index.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
+import { ChangesetConventionalCommit } from '../types';
 import {
   associateCommitsToConventionalCommitMessages,
+  difference,
   getRepoRoot,
   gitFetch,
   isBreakingChange,
@@ -198,6 +200,72 @@ describe('associate-commits-to-conventional-commit-messages', () => {
         commitHashes: ['hash4', 'hash5'],
       },
     ]);
+  });
+});
+
+describe('difference', () => {
+  const changesets = [
+    {
+      releases: [
+        { name: 'changeset-cc-test-01', type: 'minor' },
+        { name: 'changeset-cc-test-02', type: 'minor' },
+      ],
+      summary: 'feat: add cli helper and flags',
+      packagesChanged: [
+        {
+          dir: '/z/merge-requests/changeset-conventional-commits/packages/test-01',
+          relativeDir: 'packages/test-01',
+          packageJson: {},
+        },
+        {
+          dir: '/z/merge-requests/changeset-conventional-commits/packages/test-02',
+          relativeDir: 'packages/test-02',
+          packageJson: {},
+        },
+      ],
+    },
+    {
+      releases: [{ name: 'changeset-cc-test-01', type: 'minor' }],
+      summary: 'docs(changeset-cc-test-01): add update #2 and #3',
+      packagesChanged: [
+        {
+          dir: '/z/merge-requests/changeset-conventional-commits/packages/test-01',
+          relativeDir: 'packages/test-01',
+          packageJson: {},
+        },
+      ],
+    },
+  ] as ChangesetConventionalCommit[];
+
+  const currentChangesets = [
+    {
+      releases: [
+        { name: 'changeset-cc-test-01', type: 'minor' },
+        { name: 'changeset-cc-test-02', type: 'minor' },
+      ],
+      summary: 'feat: add cli helper and flags',
+      packagesChanged: [
+        {
+          dir: '/z/merge-requests/changeset-conventional-commits/packages/test-01',
+          relativeDir: 'packages/test-01',
+          packageJson: {},
+        },
+        {
+          dir: '/z/merge-requests/changeset-conventional-commits/packages/test-02',
+          relativeDir: 'packages/test-02',
+          packageJson: {},
+        },
+      ],
+    },
+  ] as ChangesetConventionalCommit[];
+
+  it('correctly detects equal changesets *without* trailing new line/line break within `summary`', () => {
+    expect(difference(changesets, currentChangesets)).toEqual([changesets[1]]);
+  });
+
+  it('correctly detects equal changesets *with* trailing new line/line break within `summary`', () => {
+    changesets[0].summary += '\n';
+    expect(difference(changesets, currentChangesets)).toEqual([changesets[1]]);
   });
 });
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -119,8 +119,8 @@ export const conventionalMessagesWithCommitsToChangesets = (
             type: isBreakingChange(entry.changelogMessage)
               ? 'major'
               : entry.changelogMessage.startsWith('feat')
-              ? 'minor'
-              : 'patch',
+                ? 'minor'
+                : 'patch',
           };
         }),
         summary: entry.changelogMessage,
@@ -162,7 +162,7 @@ export const getCommitsSinceRef = (branch: string) => {
 };
 
 const compareChangeSet = (a: Changeset, b: Changeset): boolean => {
-  return a.summary === b.summary && JSON.stringify(a.releases) == JSON.stringify(b.releases);
+  return a.summary.replace(/\n$/, '') === b.summary && JSON.stringify(a.releases) == JSON.stringify(b.releases);
 };
 
 export const difference = (a: Changeset[], b: Changeset[]): Changeset[] => {


### PR DESCRIPTION
`/src/utils/index.ts`
```ts
// return a.summary === b.summary && JSON.stringify(a.releases) == JSON.stringify(b.releases);
return a.summary.replace(/\n$/, '') === b.summary && JSON.stringify(a.releases) == JSON.stringify(b.releases);
```

See #26 for details, which this fixes.

Btw., it was the prettier on lint-staging that "huskied" with that indention.